### PR TITLE
Expanding comment functionality

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,3 +12,9 @@
 //
 //= require rails-ujs
 //= require_tree .
+
+
+  // Show form warning if empty post is submitted
+
+
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
+  include CommentsHelper
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -40,8 +40,13 @@ class CommentsController < ApplicationController
   def destroy
     @post = Post.find(params[:post_id])
     @comment = @post.comments.find(params[:id])
-    @comment.destroy
-    redirect_to posts_path(@post)
+    if @comment.destroy
+      flash[:success] = "Comment deleted"
+      redirect_back(fallback_location: posts_path)
+    else
+      flash[:danger] = "Could not delete comment"
+      redirect_back(fallback_location: posts_path)
+    end
   end
     
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,6 +29,7 @@ class CommentsController < ApplicationController
     @comment = @post.comments.find(params[:id])
 
     if @comment.update(comment_params)
+      flash[:success] = "Comment edited"
       redirect_to posts_path
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,8 +4,15 @@ class CommentsController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    @comment = @post.comments.create(comment_params.merge(user_id: current_user.id))
-    redirect_back(fallback_location: posts_path)
+    @comment = @post.comments.new(comment_params.merge(user_id: current_user.id))
+
+    if @comment.save
+      flash[:success] = "Comment posted"
+      redirect_back(fallback_location: posts_path)
+    else
+      flash[:danger] = "Unable to post comment"
+      redirect_back(fallback_location: posts_path)
+    end
   end
 
   def edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,7 +19,7 @@ class PostsController < ApplicationController
   end
 
   def index
-    @posts = Post.all
+    @posts = Post.newest_first
     @post = Post.new
   end
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,2 +1,7 @@
 module CommentsHelper
+
+  def editable?(comment)
+    Time.now - Time.parse(comment.created_at.to_s) <= 600
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  scope :newest_first, -> { order(created_at: :desc) }
   has_many :comments, dependent: :destroy
   belongs_to :user
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -117,8 +117,10 @@
 
                     <footer class="card-footer">
                       <% if current_user == @commenter %>
-                        <%= link_to '<i class="fas fa-edit"></i>'.html_safe, post_path(post) + "/comments/#{comment.id}/edit",
-                        class: "card-footer-item editbutton" %>
+                        <% if editable?(comment) %>
+                          <%= link_to '<i class="fas fa-edit"></i>'.html_safe, post_path(post) + "/comments/#{comment.id}/edit",
+                          class: "card-footer-item editbutton" %>
+                        <% end %>
                         <%= link_to '<i class="fas fa-trash-alt" aria-hidden="true"></i>'.html_safe, post_path(post) + "/comments/#{comment.id}",
                         class: "card-footer-item",
                         method: :delete,

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -117,7 +117,8 @@
 
                     <footer class="card-footer">
                       <% if current_user == @commenter %>
-                        <a href="#" class="card-footer-item"><i class="fas fa-edit"></i></a>
+                        <%= link_to '<i class="fas fa-edit"></i>'.html_safe, post_path(post) + "/comments/#{comment.id}/edit",
+                        class: "card-footer-item editbutton" %>
                         <%= link_to '<i class="fas fa-trash-alt" aria-hidden="true"></i>'.html_safe, post_path(post) + "/comments/#{comment.id}",
                         class: "card-footer-item",
                         method: :delete,

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -122,7 +122,7 @@
                           class: "card-footer-item editbutton" %>
                         <% end %>
                         <%= link_to '<i class="fas fa-trash-alt" aria-hidden="true"></i>'.html_safe, post_path(post) + "/comments/#{comment.id}",
-                        class: "card-footer-item",
+                        class: "card-footer-item deleter",
                         method: :delete,
                         data: { confirm: "Are you sure?" }
                         %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,7 +15,9 @@
       <strong><%= "#{@commenter.name}:" %></strong>
       <%= comment.message %>
       <% if current_user == @commenter %>
+      <% if editable?(comment) %>
         <%= link_to "Edit comment", post_path(@post) + "/comments/#{comment.id}/edit" %>
+      <% end %>
         <%= link_to "Delete comment", post_path(@post) + "/comments/#{comment.id}",
         method: :delete,
         data: { confirm: "Are you sure?" }

--- a/spec/features/comment/user_can_delete_comment_spec.rb
+++ b/spec/features/comment/user_can_delete_comment_spec.rb
@@ -4,12 +4,21 @@ RSpec.feature "Comments", type: :feature do
   scenario "Users can make a comment and delete it" do
     user_sign_up
     create_post
+    fill_in "comment[message]", with: "Hiya"
+    click_button "Reply"
+    find('a.deleter').click
+    expect(page).not_to have_content "Hiya"
+  end
+
+  scenario "Users get a helpful message when comment is deleted" do
+    user_sign_up
+    create_post
     log_out
     second_user_sign_up
     fill_in "comment[message]", with: "Hiya"
     click_button "Reply"
-    find('.fa-trash-alt').click
-    expect(page).not_to have_content "Kim Hiya"
+    find('a.deleter').click
+    expect(page).to have_content "Comment deleted"
   end
 
   scenario "Users can make a comment and delete it from the individual post page" do

--- a/spec/features/comment/user_can_edit_comment.rb
+++ b/spec/features/comment/user_can_edit_comment.rb
@@ -8,11 +8,11 @@ RSpec.feature "Comments", type: :feature do
     second_user_sign_up
     fill_in "comment[message]", with: "Hiya"
     click_button "Create Comment"
-    click_link "Edit comment"
+    find('a.editbutton').click
     fill_in "comment[message]", with: "Updated"
     click_button "Submit"
     expect(page).to have_content("Updated")
-    expect(page).not_to have_content "Kim Hiya"
+    expect(page).not_to have_content "Hiya"
   end
 
   scenario "Users can make a comment and edit it from the individual post page" do

--- a/spec/features/comment/user_can_edit_comment.rb
+++ b/spec/features/comment/user_can_edit_comment.rb
@@ -7,7 +7,7 @@ RSpec.feature "Comments", type: :feature do
     log_out
     second_user_sign_up
     fill_in "comment[message]", with: "Hiya"
-    click_button "Create Comment"
+    click_button "Reply"
     find('a.editbutton').click
     fill_in "comment[message]", with: "Updated"
     click_button "Submit"
@@ -34,7 +34,7 @@ RSpec.feature "Comments", type: :feature do
     user_sign_up
     create_post
     fill_in "comment[message]", with: "Hiya"
-    click_button "Create Comment"
+    click_button "Reply"
     log_out
     second_user_sign_up
     expect(page).not_to have_content("Edit comment")
@@ -44,11 +44,24 @@ RSpec.feature "Comments", type: :feature do
     user_sign_up
     create_post
     fill_in "comment[message]", with: "Hiya"
-    click_button "Create Comment"
+    click_button "Reply"
     log_out
     second_user_sign_up
     click_link "Hello, world!"
     expect(page).not_to have_content("Edit comment")
+  end
+
+  scenario "Users should see a helpful message when edit is successful" do
+    user_sign_up
+    create_post
+    log_out
+    second_user_sign_up
+    fill_in "comment[message]", with: "Hiya"
+    click_button "Reply"
+    find('a.editbutton').click
+    fill_in "comment[message]", with: "Updated"
+    click_button "Submit"
+    expect(page).to have_content("Comment edited")
   end
 
 end

--- a/spec/features/comment/user_can_make_comment_spec.rb
+++ b/spec/features/comment/user_can_make_comment_spec.rb
@@ -12,6 +12,16 @@ RSpec.feature "Comments", type: :feature do
     expect(page).to have_content "Hiya"
   end
 
+  scenario "Users should see a success message when making comment" do
+    user_sign_up
+    create_post
+    log_out
+    second_user_sign_up
+    fill_in "comment[message]", with: "Hiya"
+    click_button "Reply"
+    expect(page).to have_content "Comment posted"
+  end
+
   scenario "Users can make a comment on an individual post page and their name will appear next to it" do
     user_sign_up
     create_post

--- a/spec/features/post/user_can_view_post_from_feed_spec.rb
+++ b/spec/features/post/user_can_view_post_from_feed_spec.rb
@@ -10,4 +10,14 @@ RSpec.feature "Timeline", type: :feature do
     expect(page).to have_content("Delete post")
     expect(page).to have_button("Create Comment")
   end
+
+  scenario "Posts should be displayed in order" do
+    user_sign_up
+    create_post
+    visit "/posts"
+    form = all("form").first
+    form.fill_in "post[message]", with: "Bye, world!"
+    click_button "Post"
+    expect(all(".post-message").first).to have_content ("Bye, world!")
+  end
 end

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -11,5 +11,10 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe CommentsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  it "should be able to tell if a comment is editable" do
+    over_ten_minutes_ago = (Time.now - 601).to_s
+    comment = Comment.new(created_at: over_ten_minutes_ago)
+    expect(helper.editable?(comment)).to be false
+  end
 end


### PR DESCRIPTION
 - Linked edit comment to new interface
 - Users can only edit comments for ten minutes after posting them
 - Users get helpful messages when successfully creating, editing, or deleting comments
 - Newsfeed is shown in chronological order with newest posts first